### PR TITLE
Remove hard-coded OrganizationId to prevent overwrite of PathVariable

### DIFF
--- a/licensing-service/src/main/java/com/thoughtmechanix/licenses/controllers/LicenseServiceController.java
+++ b/licensing-service/src/main/java/com/thoughtmechanix/licenses/controllers/LicenseServiceController.java
@@ -26,8 +26,7 @@ public class LicenseServiceController {
             .withId(licenseId)
             .withOrganizationId(organizationId)
             .withProductName("Teleco")
-            .withLicenseType("Seat")
-            .withOrganizationId("TestOrg");
+            .withLicenseType("Seat");
     }
 
     @RequestMapping(value="{licenseId}",method = RequestMethod.PUT)


### PR DESCRIPTION
This issues was reported by someone else (https://github.com/carnellj/spmia-chapter2/issues/1) but I noticed it is still a problem so I fixed. after I noticed service was not working for me.